### PR TITLE
Change redirect to point to https://jj-vcs.github.io/jj/latest/, add body text

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,5 +1,8 @@
 <html>
   <head>
-    <meta http-equiv="refresh" content="0; url=https://jj-vcs.github.io/jj" />
+    <meta http-equiv="refresh" content="0; url=https://jj-vcs.github.io/jj/latest/" />
   </head>
+  <body>
+    Redirecting to <a href="https://jj-vcs.github.io/jj/latest/">https://jj-vcs.github.io/jj/latest/</a>...
+  </body>
 </html>


### PR DESCRIPTION
I initially was going to point it to `https://jj-vcs.github.io/jj/` (with a slash at the end), but it might be a bit better to avoid redirecting to another redirect.